### PR TITLE
add support for typos to pr checker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,15 @@
-FROM alpine:3.10
+FROM alpine:3.22
 RUN apk add --no-cache \
   bash \
   git \
-  ncurses
+  ncurses \
+  musl-dev \
+  wget \
+  findutils \
+  jq
+RUN wget -qO- https://api.github.com/repos/crate-ci/typos/releases/latest \
+  | jq -r '.assets | map(select(.name | match("x86_64-.*-linux.*.tar.gz")))[0] | .browser_download_url' \
+  | xargs wget
+RUN tar -C/bin -xzf /typos-*.tar.gz ./typos
 COPY check-pr-commits.sh /check-pr-commits.sh
 ENTRYPOINT ["/bin/bash", "/check-pr-commits.sh"]

--- a/check-pr-commits.sh
+++ b/check-pr-commits.sh
@@ -157,6 +157,19 @@ body_is_empty() {
     return 1
 }
 
+#  Run typos check on PR commit messages
+has_typos() {
+    sha=$1
+    message=$(git show -s --format=%B $sha)
+    commit_misspellings=$(echo ${message} | typos --diff - | wc -l)
+    if test ${commit_misspellings} -ne 0; then
+        # if typos exist, show them and return 0
+        log "$(echo ${message} | typos -)"
+        return 0
+    fi
+    return 1
+}
+
 #  Add more test functions here...
 
 #############################################################################
@@ -173,7 +186,8 @@ check_commit() {
        is_merge_commit $sha || \
        subject_length_exceeds 70 $sha || \
        body_is_empty $sha || \
-       body_line_length_exceeds 78 $sha; then
+       body_line_length_exceeds 78 $sha || \
+       has_typos $sha; then
         symbol="$(notok)"
         result=1
     else


### PR DESCRIPTION
It's bothered me for a while that we manually check spelling on PRs, but until today it didn't occur to me this could be part of the PR validator. 

For a demo, go to flux-core and run `/path/to/pr-validator/check-pr-commits.sh 7c6746e2d` and, while the flux developers never misspell anything, after a minute or two you _might_ see a few examples left behind solely for the purpose of demonstrating this feature!

In my mind, there is one con, and that' the difference in timing of container build. On my local machine, after this change the container went from building in 2.7s to taking 95.5s. 

