### PR TITLE
typos: fix bug with dubious git ownership

### DIFF
--- a/check-pr-commits.sh
+++ b/check-pr-commits.sh
@@ -206,6 +206,9 @@ check_commit() {
 #  Main loop:
 
 printf "Validating commits on current branch:\n"
+if git status 2>&1 >/dev/null  | grep -q "dubious ownership" || true; then
+    git config --global --add safe.directory $(pwd)
+fi
 
 COMMITS=$(git log --format=%h ${BASE}..${HEAD})
 for sha in $COMMITS; do


### PR DESCRIPTION
Problem: after the last commit went in, adding support for typos, all of the GitHub Actions started failing due to a git ownership-related error.

Check the ownership of the repo being evaluated. If it's dubious, tell git to ignore its ownership.

@grondo feel free to push here if something is awry.