### PR TITLE
move workaround for git dubious ownership to top of script

### DIFF
--- a/check-pr-commits.sh
+++ b/check-pr-commits.sh
@@ -12,6 +12,11 @@
 set -e
 set -o pipefail
 
+# Fix "dubious ownership" error if necessary before first git command:
+if git status 2>&1 >/dev/null  | grep -q "dubious ownership" || true; then
+    git config --global --add safe.directory $(pwd)
+fi
+
 origin_main() {
     git rev-parse --verify origin/main >/dev/null 2>&1 \
     && echo origin/main \
@@ -206,9 +211,6 @@ check_commit() {
 #  Main loop:
 
 printf "Validating commits on current branch:\n"
-if git status 2>&1 >/dev/null  | grep -q "dubious ownership" || true; then
-    git config --global --add safe.directory $(pwd)
-fi
 
 COMMITS=$(git log --format=%h ${BASE}..${HEAD})
 for sha in $COMMITS; do


### PR DESCRIPTION
Problem: On projects with a `main` branch instead of `master` `check-pr-commits.sh` fails because `origin_main()` always returns `origin/master` due to a "dubious ownership" error from git.  The workaround for this issue is run too late in the script, after `$BASE` has already been computed.

Move the fix for the "dubious ownership" error to the top of the script so that it runs, if necessary, before the first git command.